### PR TITLE
fix(deps): override shell-quote >=1.8.4 to clear critical npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4631,9 +4631,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7412,7 +7412,7 @@
       "requires": {
         "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
+        "shell-quote": ">=1.8.4",
         "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
         "yargs": "17.7.2"
@@ -8899,9 +8899,9 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true
     },
     "siginfo": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "overrides": {
     "form-data": ">=4.0.4",
-    "follow-redirects": ">=1.15.6"
+    "follow-redirects": ">=1.15.6",
+    "shell-quote": ">=1.8.4"
   }
 }


### PR DESCRIPTION
## What

The full `npm audit --package-lock-only` CI gate is failing on a **critical** advisory, which in turn blocks the open Dependabot PRs (#84, #85) since they all share the same gating audit job.

### Offending package

```
@openapitools/openapi-generator-cli  (devDependency)
  └─ concurrently@9.2.1
       └─ shell-quote@1.8.3   ← vulnerable
```

- Advisory: [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) — *shell-quote `quote()` does not escape newlines in object `.op` values* (severity: **critical**)
- Vulnerable range: `1.1.0 - 1.8.3`
- Fixed in: `1.8.4`

`shell-quote` is a deep transitive **dev** dependency (no upstream release of `@openapitools/openapi-generator-cli` / `concurrently` yet pulls the fix), so it can't be resolved by a direct bump.

## Change

Add an `overrides` entry pinning `shell-quote >=1.8.4`, matching the existing `form-data` / `follow-redirects` supply-chain-floor pattern in `package.json`.

## Verification

```
$ npm install --package-lock-only
$ npm audit --package-lock-only
found 0 vulnerabilities

$ npm ls shell-quote
└─┬ @openapitools/openapi-generator-cli@2.34.0
  └─┬ concurrently@9.2.1
    └── shell-quote@1.8.4
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)