### PR TITLE
build: add Socket.dev supply-chain hardening (free, zero-cost)

### DIFF
--- a/.github/workflows/cd-publish-to-npm.yml
+++ b/.github/workflows/cd-publish-to-npm.yml
@@ -52,6 +52,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
       - run: java -version
+      # Socket Firewall Free (sfw): blocks confirmed-malware fetches at install time —
+      # the behavioural layer `npm audit` (CVE-only) misses. firewall-free needs no token.
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          job-summary: all
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-root
         with:
@@ -60,11 +66,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-root-
       - run: npm audit --package-lock-only
-      - run: npm ci
+      - run: sfw npm ci
       # Use the lockfile-pinned generator (a devDependency), not an unpinned global
       # `npm install -g @latest`. npx resolves to the local node_modules copy, so the
       # version is reproducible, audited (it's in the lockfile), and bumped via Dependabot.
-      - run: npx @openapitools/openapi-generator-cli version
+      - run: sfw npx @openapitools/openapi-generator-cli version
       - run: npm run openapi:set:version
       - run: npm run openapi:generate
       - run: npm run build
@@ -94,6 +100,10 @@ jobs:
         with:
           name: dist-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.java-version }}-${{ matrix.node-version }}
           path: dist/
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          job-summary: all
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-root-test
         with:
@@ -102,7 +112,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-root-
       - run: npm audit --package-lock-only
-      - run: npm ci
+      - run: sfw npm ci
       # Defence in depth: fail the gating job when the resolved axios is below the
       # known-CVE-free floor (proves the package.json `overrides` took effect).
       - name: Verify resolved axios meets the security floor
@@ -135,6 +145,10 @@ jobs:
         with:
           name: dist-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.java-version }}-${{ matrix.node-version }}
           path: dist/
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          job-summary: all
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-nodejs-javascript
         with:
@@ -144,7 +158,7 @@ jobs:
             ${{ runner.os }}-node-${{ matrix.node-version }}-nodejs-javascript-
       - run: npm audit --package-lock-only
         working-directory: ./tests/nodejs-javascript
-      - run: npm ci
+      - run: sfw npm ci
         working-directory: ./tests/nodejs-javascript
       - run: npm test
         working-directory: ./tests/nodejs-javascript
@@ -172,6 +186,10 @@ jobs:
         with:
           name: dist-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.java-version }}-${{ matrix.node-version }}
           path: dist/
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          job-summary: all
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-nodejs-typescript
         with:
@@ -181,7 +199,7 @@ jobs:
             ${{ runner.os }}-node-${{ matrix.node-version }}-nodejs-typescript-
       - run: npm audit --package-lock-only
         working-directory: ./tests/nodejs-typescript
-      - run: npm ci
+      - run: sfw npm ci
         working-directory: ./tests/nodejs-typescript
       - run: npm test
         working-directory: ./tests/nodejs-typescript
@@ -212,6 +230,12 @@ jobs:
         with:
           name: dist-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.java-version }}-${{ matrix.node-version }}
           path: dist/
+      # This job runs in the playwright container as --user 1001; if sfw's binary
+      # download fails here it only affects this job, which is continue-on-error.
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          job-summary: all
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-browser-cdn
         with:
@@ -221,7 +245,7 @@ jobs:
             ${{ runner.os }}-node-${{ matrix.node-version }}-browser-cdn-
       - run: npm audit --package-lock-only
         working-directory: ./tests/browser-cdn
-      - run: npm ci
+      - run: sfw npm ci
         working-directory: ./tests/browser-cdn
       - run: npm run test
         working-directory: ./tests/browser-cdn
@@ -254,6 +278,10 @@ jobs:
         with:
           name: dist-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.java-version }}-${{ matrix.node-version }}
           path: dist/
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          job-summary: all
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-root-publish
         with:
@@ -262,7 +290,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-root-
       - run: npm audit --package-lock-only
-      - run: npm ci
+      - run: sfw npm ci
       # Trusted Publishing (OIDC) requires npm >= 11.5.1, which ships by default with
       # Node.js 24.x — so we do NOT `npm install -g npm@latest` (that would add a
       # fresh, unpinned global package to the privileged id-token step). Just assert

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -42,6 +42,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
       - run: java -version
+      # Socket Firewall Free (sfw): blocks confirmed-malware fetches at install time —
+      # the behavioural layer `npm audit` (CVE-only) misses. firewall-free needs no token.
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          job-summary: all
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-root
         with:
@@ -50,11 +56,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-root-
       - run: npm audit --package-lock-only
-      - run: npm ci
+      - run: sfw npm ci
       # Use the lockfile-pinned generator (a devDependency), not an unpinned global
       # `npm install -g @latest`. npx resolves to the local node_modules copy, so the
       # version is reproducible, audited (it's in the lockfile), and bumped via Dependabot.
-      - run: npx @openapitools/openapi-generator-cli version
+      - run: sfw npx @openapitools/openapi-generator-cli version
       - run: npm run openapi:set:version
       - run: npm run openapi:generate
       - run: npm run build
@@ -85,6 +91,10 @@ jobs:
         with:
           name: dist-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.java-version }}-${{ matrix.node-version }}
           path: dist/
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          job-summary: all
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-root-test
         with:
@@ -93,7 +103,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-root-
       - run: npm audit --package-lock-only
-      - run: npm ci
+      - run: sfw npm ci
       # Defence in depth: even if `npm audit` misses something (e.g. a known-bad axios
       # version with no advisory filed yet), fail this gating job when the resolved axios
       # is below the known-CVE-free floor. The `overrides` in package.json force the safe
@@ -129,6 +139,10 @@ jobs:
         with:
           name: dist-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.java-version }}-${{ matrix.node-version }}
           path: dist/
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          job-summary: all
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-nodejs-javascript
         with:
@@ -138,7 +152,7 @@ jobs:
             ${{ runner.os }}-node-${{ matrix.node-version }}-nodejs-javascript-
       - run: npm audit --package-lock-only
         working-directory: ./tests/nodejs-javascript
-      - run: npm ci
+      - run: sfw npm ci
         working-directory: ./tests/nodejs-javascript
       - run: npm test
         working-directory: ./tests/nodejs-javascript
@@ -167,6 +181,10 @@ jobs:
         with:
           name: dist-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.java-version }}-${{ matrix.node-version }}
           path: dist/
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          job-summary: all
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-nodejs-typescript
         with:
@@ -176,7 +194,7 @@ jobs:
             ${{ runner.os }}-node-${{ matrix.node-version }}-nodejs-typescript-
       - run: npm audit --package-lock-only
         working-directory: ./tests/nodejs-typescript
-      - run: npm ci
+      - run: sfw npm ci
         working-directory: ./tests/nodejs-typescript
       - run: npm test
         working-directory: ./tests/nodejs-typescript
@@ -208,6 +226,12 @@ jobs:
         with:
           name: dist-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.java-version }}-${{ matrix.node-version }}
           path: dist/
+      # This job runs in the playwright container as --user 1001; if sfw's binary
+      # download fails here it only affects this job, which is continue-on-error.
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          job-summary: all
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-browser-cdn
         with:
@@ -217,7 +241,7 @@ jobs:
             ${{ runner.os }}-node-${{ matrix.node-version }}-browser-cdn-
       - run: npm audit --package-lock-only
         working-directory: ./tests/browser-cdn
-      - run: npm ci
+      - run: sfw npm ci
         working-directory: ./tests/browser-cdn
       - run: npm run test
         working-directory: ./tests/browser-cdn
@@ -249,6 +273,10 @@ jobs:
         with:
           name: dist-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.java-version }}-${{ matrix.node-version }}
           path: dist/
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          job-summary: all
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-root-dry-run
         with:
@@ -257,7 +285,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-root-
       - run: npm audit --package-lock-only
-      - run: npm ci
+      - run: sfw npm ci
       # Validate the SAME tree CD publishes (./dist) by packing it. We use `npm pack`,
       # not `npm publish --dry-run`: the latter contacts the registry and fails with
       # "cannot publish over previously published versions" because the version isn't
@@ -275,6 +303,10 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          job-summary: all
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-lint
         with:
@@ -283,7 +315,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-24.x-root-
       - run: npm audit --package-lock-only
-      - run: npm ci
+      - run: sfw npm ci
       - run: npm run format:check
       - run: npm run lint
       - run: npm run type:check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,19 @@ Both workflows:
   spec's tamper check (the role the old `SPEC_SHA256` played).
 - **Install-time**: `.npmrc` sets `ignore-scripts=true` (blocks malicious postinstall in the deeper axios
   transitive tree) and `min-release-age=7` (local cooldown; `npm ci` is unaffected and gated by `npm audit`).
+- **Behavioural supply-chain layer (Socket.dev, free for this public repo)**: complements `npm audit`, which
+  only sees *CVE-registered* flaws. Two layers, zero cost, no API token:
+  - **Socket GitHub App** (`socket.yml` at root) — reads only dependency manifests (never source) and
+    comments supply-chain risk on PRs (malware, typosquats, install scripts, obfuscation, network/shell
+    access, maintainer changes). Primary target: Dependabot PRs. Installed once via the GitHub Marketplace
+    (org-admin action, outside the repo).
+  - **Socket Firewall Free (`sfw`)** in CI/CD — `SocketDev/action@<sha>` (`mode: firewall-free`, SHA-pinned
+    for `pinact`, tracked by the github-actions Dependabot) installs `sfw`; every `npm ci` / `npx` is run as
+    `sfw npm ci` so *confirmed malware* is blocked at fetch time (gates the gating jobs; AI-only detections
+    warn, not block, so no false-positive build breaks). The container `test-browser-cdn` job applies it too
+    but is `continue-on-error`, so an sfw download failure there never reds CI.
+  - **NOT used**: `socket optimize` (its `@socketregistry` overrides would fight the hand-managed `overrides`
+    block above).
 
 ## Important Notes
 

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,27 @@
+# Socket.dev GitHub App configuration.
+# Free for public/open-source repos: the App reads only dependency manifests
+# (never source code) and posts supply-chain risk findings on PRs. It is the
+# behavioural-risk layer (malware, typosquats, install scripts, obfuscation,
+# network/shell access, maintainer changes) that `npm audit` (CVE-only) cannot see.
+# https://docs.socket.dev/docs/socket-yml
+version: 2
+
+# Build outputs / generated code are not dependency manifests — skip them.
+projectIgnorePaths:
+  - dist
+  - src/api
+
+# Re-scan a PR only when a manifest actually changes (covers the monorepo test roots).
+triggerPaths:
+  - package.json
+  - package-lock.json
+  - tests/**/package.json
+  - tests/**/package-lock.json
+
+githubApp:
+  enabled: true
+  pullRequestAlertsEnabled: true
+  dependencyOverviewEnabled: true
+  projectReportsEnabled: true
+  # Do NOT ignore Dependabot: its PRs are the main entry point for new
+  # dependencies and therefore the primary target of Socket's review.


### PR DESCRIPTION
## Overview

Adds a **behavioural supply-chain security layer** via Socket.dev to complement `npm audit` (which only detects CVE-registered vulnerabilities). This repo is public open source, so there is **zero added cost and no API token required**.

## Design (two layers)

| Layer | Role | Cost |
|---|---|---|
| **Socket GitHub App** (`socket.yml`) | Reads dependency manifests only and comments supply-chain risk on PRs (malware / typosquats / install scripts / obfuscation / network & shell access / maintainer changes). Primary target: Dependabot PRs | Free, no workflow change |
| **Socket Firewall Free `sfw`** (CI/CD) | Blocks **confirmed malware at fetch time** during `npm ci`/`npx`. Adds active blocking on top of the App's review | Free, no token |

## Changes

- **`socket.yml`** (new, repo root): GitHub App config. Excludes generated `dist`/`src/api` from scanning, triggers on manifest changes including `tests/**`, enables PR comments. Does **not** ignore Dependabot (its PRs are the main entry point for new dependencies).
- **`.github/workflows/ci-nodejs.yml` / `cd-publish-to-npm.yml`**: Adds `SocketDev/action@ba6de6c…` (v1.3.2, `mode: firewall-free`, SHA-pinned) to each job and wraps every `npm ci`/`npx` (15 call sites) with `sfw`.
  - Gating jobs fail the build on confirmed malware. AI-only detections only warn (no false-positive build breaks).
  - The `test-browser-cdn` job applies it too but stays `continue-on-error` (an `sfw` download failure in the container never reds CI).
- **`CLAUDE.md`**: Documents this layer and why `socket optimize` is not used (it would conflict with the hand-managed axios `overrides`).

## Relationship to existing mechanisms (no overlap, no conflict)

- `sfw` blocks **malware fetches**, not CVEs → complements `npm audit`.
- The action is SHA-pinned, so it **passes the existing `pinact` gate** (local `pinact run --check` is green). The `github-actions` Dependabot tracks it automatically.

## Review focus

- The `SocketDev/action` step succeeds and `sfw npm ci` completes without false-blocking legitimate dependencies.
- The `npm audit` gate and the axios floor check stay green (no regression).

## Remaining manual step (after merge, free)

- **Install the Socket GitHub App** (requires org-admin, outside the repo): add https://github.com/apps/socket-security to the `nemtus` org for this repository. This enables the PR review layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)